### PR TITLE
Add One-to-Many Relationship with Definitions and Example Sentences

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,6 +80,7 @@ model Definition {
   text    String
   usageID BigInt?
   groupID BigInt?
+  sentences Sentences[]
 
   Group Group? @relation(fields: [groupID], references: [id])
   Usage Usage? @relation(fields: [usageID], references: [id])
@@ -90,6 +91,9 @@ model Definition {
 model Sentences {
   id   BigInt @id @default(autoincrement()) @db.BigInt
   text String
+  definitionID BigInt
+
+  Definition Definition @relation(fields: [definitionID], references: [id])
 
   @@map("sentences")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,7 +80,7 @@ model Definition {
   text    String
   usageID BigInt?
   groupID BigInt?
-  sentences Sentences[]
+  examples Example[]
 
   Group Group? @relation(fields: [groupID], references: [id])
   Usage Usage? @relation(fields: [usageID], references: [id])
@@ -88,12 +88,12 @@ model Definition {
   @@map("definitions")
 }
 
-model Sentences {
+model Example {
   id   BigInt @id @default(autoincrement()) @db.BigInt
   text String
   definitionID BigInt
 
   definition Definition @relation(fields: [definitionID], references: [id])
 
-  @@map("sentences")
+  @@map("examples")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -93,7 +93,7 @@ model Sentences {
   text String
   definitionID BigInt
 
-  Definition Definition @relation(fields: [definitionID], references: [id])
+  definition Definition @relation(fields: [definitionID], references: [id])
 
   @@map("sentences")
 }


### PR DESCRIPTION
This PR will add a one-to-many relationship between definitions and example sentences in the database. I think this can be updated with a `prisma migrate`. I think this should be the last change to the DB before we start on the docker-compose file.